### PR TITLE
ci: update the name in the package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "lunastationquarterly",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.4.1",


### PR DESCRIPTION
Looks like the lockfile was missing the name for whatever reason for me, so I think it's updated correctly now? 