### PR TITLE
feat: create contact us page

### DIFF
--- a/src/pages/contact-us.astro
+++ b/src/pages/contact-us.astro
@@ -1,0 +1,59 @@
+---
+import Page from "../layouts/Page.astro";
+---
+
+<Page title="Contact Us" description="Contact Us">
+    <h2 class="text-4xl font-sans">Contact Us</h2>
+    <div class="mt-3 mb-6 border-b-subfooter border-lsq-orange w-24" />
+    <p class="mb-10 italic text-lsq-gray">
+        Fields marked with an <span class="text-lsq-orange">*</span> are required.
+    </p>
+    <form action="https://formspree.io/f/mzbnzjpa" method="POST" class="pt-6 pb-8 mb-4">
+        <div class="mb-4">
+            <label class="block text-gray-700 mb-2" for="email">
+                Name
+                <span class="font-bold text-lsq-orange">*</span>
+            </label>
+            <input
+                class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline"
+                id="name"
+                name="name"
+                placeholder="Name"
+            />
+        </div>
+        <div class="mb-4">
+            <label class="block text-gray-700 mb-2" for="email">
+                Email
+                <span class="text-lsq-orange">*</span>
+            </label>
+            <input
+                class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 focus:outline-none focus:shadow-outline"
+                id="email"
+                name="email"
+                type="email"
+                placeholder="Email address" 
+            />
+        </div>
+        <div class="mb-6">
+            <label class="block text-gray-700 mb-2" for="message">
+                Message
+                <span class="text-lsq-orange">*</span>
+            </label>
+            <textarea
+                class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 mb-3 focus:outline-none focus:shadow-outline"
+                id="message"
+                rows="5"
+                name="message"
+                placeholder="Message"
+            />
+        </div>
+        <div class="flex items-center justify-between">
+            <button
+                class="bg-lsq-orange hover:bg-lsq-orange-light text-lsq-white py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                type="submit"
+                >
+                Send
+            </button>
+        </div>
+    </form>
+</Page>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -25,6 +25,7 @@ export default {
 			'lsq-green': '#b6ac31',
 			'lsq-orange': '#d24719',
 			'lsq-orange-light': '#DC6D48',
+			'lsq-gray': '#3d3d3d',
 			'lsq-white': '#ffffff',
 			'lsq-black': '#222222',
 		},


### PR DESCRIPTION
Closes #21 
## Notes for reviewers
- I added a new color, `lsq-grey` since there was text that was in grey on the page.

### Follow up work not handled in this PR
This contact us page will need to be linked to in the subfooter. This will be handled by #34.
This needs to be linked to correctly with #4.
The form on the homepage will be deleted by #47.

## Questions for reviewers
- I'm not actually sure if submit works. I sent a test submission, but I don't have access to that form thingie, so I can't check if it actually went through. 

<img width="1101" alt="image" src="https://github.com/jenniferlynparsons/lunastationquarterly/assets/6477059/a745bd32-5067-436b-9516-c84000092d47">
