### PR TITLE
feat: add contact us link to the subfooter

### DIFF
--- a/src/components/Subfooter.astro
+++ b/src/components/Subfooter.astro
@@ -8,10 +8,18 @@ import SubfooterHeader from "./SubfooterHeader.astro";
   <div class="w-full h-full flex-grow p-3 overflow-auto">
     <SubfooterHeader title="A bit about us" />
     <p class="leading-8">
-      The on-going mission of Luna Station Quartery is to display the vast and varied talents of female-identified
+      The on-going mission of Luna Station Quarterly is to display the vast and varied talents of female-identified
       speculative fiction writers. We believe that women have a unique and universal voice in fiction and we aim to get
-      it heard. We hope you enjoy the stories within. Please be sure to check out our author's profiles to learn where
+      it heard. 
+    </p>
+    <p class="leading-8">
+      We hope you enjoy the stories within. Please be sure to check out our author's profiles to learn where
       you can read more of their work.
+    </p>
+    <p class="leading-8">
+      If you have any thoughts you&apos;d like to share about the site, please feel free to use the 
+      <a class="text-lsq-orange hover:text-lsq-orange-light underline" href="/contact-us">contact form</a>
+      and let us know what you think!
     </p>
   </div>
 


### PR DESCRIPTION
Closes #33 

feat: add contact us link to the subfooter
fix: fix typo on Quarterly
fix: break up paragraphs better

## Note for reviewer
I made the text color on hover be `lsq-light-orange` instead of gray because that's what I saw other links on the site doing, but let me know if that behavior is incorrect.


## Screenshot
<img width="1093" alt="image" src="https://github.com/jenniferlynparsons/lunastationquarterly/assets/6477059/80a9e407-e137-4795-af9c-039052714774">
