### PR TITLE
bug: update button styling

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -4,7 +4,7 @@ const { url, linkText } = Astro.props;
 
 <a
   href={url}
-  class="inline-block mt-2 items-center bg-lsq-orange hover:bg-lsq-orange-light text-lsq-white hover: text-lsq-white py-2 px-4 rounded focus:outline-none focus:shadow-outline no-underline font-sans not-prose"
+  class="inline-block mt-2 items-center bg-lsq-orange hover:bg-lsq-green hover:duration-500 text-lsq-white hover:text-lsq-white py-2 px-4 rounded focus:outline-none focus:ring focus:ring-lsq-orange-light no-underline font-sans not-prose uppercase"
 >
   {linkText}
 </a>


### PR DESCRIPTION
First commit!

Changed button hover color to LSQ green.
Removed extra space in hover:text-lsq-white to ensure button hover text is white.

Closes #45 

I also...
Added hover:duration-500 to make the hover state transition appear a little slower.
Changed focus:shadow-outline to focus:ring because focus:shadow-outline was replaced by focus:ring in Tailwind CSS v2.0.
Added LSQ light orange to outline on focus. (Please let me know if you like this particular styling or not!)
Changed button text to uppercase to match how the button was styled on the previous version of the website.