### PR TITLE
enhancement: add ISBN to issue pages (again)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -42,5 +42,3 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
-
-<script defer data-domain="lunastationquarterly.com" src="https://plausible.io/js/script.js"></script>

--- a/src/content/blog/close-subs-0225.md
+++ b/src/content/blog/close-subs-0225.md
@@ -1,0 +1,26 @@
+---
+title: Submissions are now closed
+pubDate: "Feburary 16, 2025"
+author: Jennifer Lyn Parsons
+heroImage: close-subs-1124.jpg
+heroAltText: "Closed sign"
+excerpt: We're currently closed for submissions. We will be reopening submissions on March 15th.
+postCategory: News
+categorySlug: /news
+---
+
+Hello, friends.
+
+I hope that wherever you are in the world, you're reading good books and treating yourself gently.
+
+<h3>Submissions are now closed</h3>
+
+We will be reopening submissions on March 15th. Mark your calendars or <a href="https://mailchi.mp/c80088306c62/luna-station-quarterly-newsletter">sign up for our newsletter</a> to get notified. 
+
+<h3>While you wait</h3>
+
+If you'd like to submit something, we'd love to read it. You can prepare by <a href="https://www.lunastationquarterly.com/submissions/">reading our submission guidelines</a>.
+
+<h3>Wrap up</h3>
+
+That's all the news for now. I hope the rest of this month treats you well.

--- a/src/content/issues/021.md
+++ b/src/content/issues/021.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '021'
 volumeNumber: 'Six'
-isbn10:
-isbn13:
+isbn10: '193869757X'
+isbn13: '978-1938697579'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/022.md
+++ b/src/content/issues/022.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '022'
 volumeNumber: 'Six'
-isbn10:
-isbn13:
+isbn10: '1938697626'
+isbn13: '978-1938697623'
 
 coverImage: 022cover.jpg
 coverTitle:

--- a/src/content/issues/023.md
+++ b/src/content/issues/023.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '023'
 volumeNumber: 'Six'
-isbn10:
-isbn13:
+isbn10: '1938697685'
+isbn13: '978-1938697685'
 
 coverImage: 023cover.jpg
 coverTitle:

--- a/src/content/issues/024.md
+++ b/src/content/issues/024.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '024'
 volumeNumber: 'Six'
-isbn10:
-isbn13:
+isbn10: '1938697715'
+isbn13: '978-1938697715'
 
 coverImage: 024cover.jpg
 coverTitle:

--- a/src/content/issues/025.md
+++ b/src/content/issues/025.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '025'
 volumeNumber: 'Seven'
-isbn10:
-isbn13:
+isbn10: '193869774X'
+isbn13: '978-1938697746'
 
 coverImage: 025cover.jpg
 coverTitle:

--- a/src/content/issues/026.md
+++ b/src/content/issues/026.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '026'
 volumeNumber: 'Seven'
-isbn10:
-isbn13:
+isbn10: '1938697766'
+isbn13: '978-1938697760'
 
 coverImage: 026cover.jpg
 coverTitle:

--- a/src/content/issues/027.md
+++ b/src/content/issues/027.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '027'
 volumeNumber: 'Seven'
-isbn10:
-isbn13:
+isbn10: '1938697790'
+isbn13: '978-1938697791'
 
 coverImage: 027cover.jpg
 coverTitle:

--- a/src/content/issues/028.md
+++ b/src/content/issues/028.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '028'
 volumeNumber: 'Seven'
-isbn10:
-isbn13:
+isbn10: '1938697812'
+isbn13: '978-1938697814'
 
 coverImage: 028cover.jpg
 coverTitle:

--- a/src/content/issues/029.md
+++ b/src/content/issues/029.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '029'
 volumeNumber: 'Eight'
-isbn10:
-isbn13:
+isbn10: '1938697839'
+isbn13: '978-1938697838'
 
 coverImage: 029cover.jpg
 coverTitle:

--- a/src/content/issues/030.md
+++ b/src/content/issues/030.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '030'
 volumeNumber: 'Eight'
-isbn10:
-isbn13:
+isbn10: '1938697855'
+isbn13: '978-1938697852'
 
 coverImage: 030cover.jpg
 coverTitle:

--- a/src/content/issues/031.md
+++ b/src/content/issues/031.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '031'
 volumeNumber: 'Eight'
-isbn10:
-isbn13:
+isbn10: '1938697871'
+isbn13: '978-1938697876'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/032.md
+++ b/src/content/issues/032.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '032'
 volumeNumber: 'Eight'
-isbn10:
-isbn13:
+isbn10: '193869791X'
+isbn13: '978-1938697913'
 
 coverImage: 032cover.jpg
 coverTitle:

--- a/src/content/issues/033.md
+++ b/src/content/issues/033.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '033'
 volumeNumber: 'Nine'
-isbn10:
-isbn13:
+isbn10: '1938697952'
+isbn13: '978-1938697951'
 
 coverImage: 033cover.jpg
 coverTitle:

--- a/src/content/issues/034.md
+++ b/src/content/issues/034.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '034'
 volumeNumber: 'Nine'
-isbn10:
-isbn13:
+isbn10: '1938697979'
+isbn13: '978-1938697975'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/035.md
+++ b/src/content/issues/035.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '035'
 volumeNumber: 'Nine'
-isbn10:
-isbn13:
+isbn10: '1949077004'
+isbn13: '978-1949077001'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/036.md
+++ b/src/content/issues/036.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '036'
 volumeNumber: 'Nine'
-isbn10:
-isbn13:
+isbn10: '1949077020'
+isbn13: '978-1949077025'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/037.md
+++ b/src/content/issues/037.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '037'
 volumeNumber: 'Ten'
-isbn10:
-isbn13:
+isbn10: '1949077063'
+isbn13: '978-1949077063'
 
 coverImage: 037cover.jpg
 coverTitle:

--- a/src/content/issues/038.md
+++ b/src/content/issues/038.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '038'
 volumeNumber: 'Ten'
-isbn10:
-isbn13:
+isbn10: '194907708X'
+isbn13: '978-1949077087'
 
 coverImage: 038cover.jpg
 coverTitle:

--- a/src/content/issues/039.md
+++ b/src/content/issues/039.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '039'
 volumeNumber: 'Ten'
-isbn10:
-isbn13:
+isbn10: '1949077101'
+isbn13: '978-1949077100'
 
 coverImage: 039cover.jpg
 coverTitle:

--- a/src/content/issues/040.md
+++ b/src/content/issues/040.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '040'
 volumeNumber: 'Ten'
-isbn10:
-isbn13:
+isbn10: '1949077136'
+isbn13: '978-1949077131'
 
 coverImage: 040cover.jpg
 coverTitle:

--- a/src/content/issues/041.md
+++ b/src/content/issues/041.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '041'
 volumeNumber: 'Eleven'
-isbn10:
-isbn13:
+isbn10: '194907711X'
+isbn13: '978-1949077117'
 
 coverImage: 041cover.jpg
 coverTitle:

--- a/src/content/issues/042.md
+++ b/src/content/issues/042.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '042'
 volumeNumber: 'Eleven'
-isbn10:
-isbn13:
+isbn10: '1949077160'
+isbn13: '978-1949077162'
 
 coverImage: 042cover.jpg
 coverTitle:

--- a/src/content/issues/043.md
+++ b/src/content/issues/043.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '043'
 volumeNumber: 'Eleven'
-isbn10:
-isbn13:
+isbn10: '1949077187'
+isbn13: '978-1949077186'
 
 coverImage: 043cover.jpg
 coverTitle:

--- a/src/content/issues/044.md
+++ b/src/content/issues/044.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '044'
 volumeNumber: 'Eleven'
-isbn10:
-isbn13:
+isbn10: '1949077209'
+isbn13: '978-1949077209'
 
 coverImage: 044cover.jpg
 coverTitle:

--- a/src/content/issues/045.md
+++ b/src/content/issues/045.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '045'
 volumeNumber: 'Twelve'
-isbn10:
-isbn13:
+isbn10: '1949077225'
+isbn13: '978-1949077223'
 
 coverImage: 045cover.jpg
 coverTitle:

--- a/src/content/issues/046.md
+++ b/src/content/issues/046.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '046'
 volumeNumber: 'Twelve'
-isbn10:
-isbn13:
+isbn10: '1949077241'
+isbn13: '978-1949077247'
 
 coverImage: 046cover.jpg
 coverTitle:

--- a/src/content/issues/047.md
+++ b/src/content/issues/047.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '047'
 volumeNumber: 'Twelve'
-isbn10:
-isbn13:
+isbn10: '1949077268'
+isbn13: '978-1949077261'
 
 coverImage: 047cover.jpg
 coverTitle:

--- a/src/content/issues/048.md
+++ b/src/content/issues/048.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '048'
 volumeNumber: 'Twelve'
-isbn10:
-isbn13:
+isbn10: '1949077284'
+isbn13: '978-1949077285'
 
 coverImage: 048cover.jpg
 coverTitle:

--- a/src/content/issues/049.md
+++ b/src/content/issues/049.md
@@ -8,14 +8,14 @@ currentIssue: false
 
 issueNumber: '049'
 volumeNumber: 'Thirteen'
-isbn10:
-isbn13:
+isbn10: '1949077306'
+isbn13: '978-1949077308'
 
 coverImage: 049cover.jpg
 coverTitle:
 
-artistName:
-artistLink:
+artistName: Caroline Jamhour
+artistLink: http://www.carolinejamhour.com/
 
 stories: 
 
@@ -27,7 +27,7 @@ authors:
 amazonLink: https://www.amazon.com/dp/1949077306
 gumroadLink: https://lunastationpress.gumroad.com/l/lsq-049
 weightlessLink: http://weightlessbooks.com/format/luna-station-quarterly-issue-49
-koboLink:
+koboLink: https://www.kobo.com/us/en/ebook/luna-station-quarterly-issue-049
 kindleLink: https://www.amazon.com/Luna-Station-Quarterly-Issue-049/dp/B09TJV8YWK
 payhipLink: 
 ---

--- a/src/content/issues/050.md
+++ b/src/content/issues/050.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '050'
 volumeNumber: 'Thirteen'
-isbn10:
-isbn13:
+isbn10: '1949077330'
+isbn13: '978-1949077339'
 
 coverImage: 050cover.jpg
 coverTitle:

--- a/src/content/issues/051.md
+++ b/src/content/issues/051.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '051'
 volumeNumber: 'Thirteen'
-isbn10:
-isbn13:
+isbn10: '1949077365'
+isbn13: '978-1949077360'
 
 coverImage: 051cover.jpg
 coverTitle:

--- a/src/content/issues/052.md
+++ b/src/content/issues/052.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '052'
 volumeNumber: 'Thirteen'
-isbn10:
-isbn13:
+isbn10: '1949077381'
+isbn13: '978-1949077384'
 
 coverImage: 052cover.jpg
 coverTitle:

--- a/src/content/issues/053.md
+++ b/src/content/issues/053.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '053'
 volumeNumber: 'Fourteen'
-isbn10:
-isbn13:
+isbn10: '1949077403'
+isbn13: '978-1949077407'
 
 coverImage:
 coverTitle:

--- a/src/content/issues/054.md
+++ b/src/content/issues/054.md
@@ -8,8 +8,8 @@ currentIssue: false
 
 issueNumber: '054'
 volumeNumber: 'Fourteen'
-isbn10:
-isbn13:
+isbn10: '194907742X'
+isbn13: '978-1949077421'
 
 coverImage: 054cover.jpg
 coverTitle:

--- a/src/pages/submissions.astro
+++ b/src/pages/submissions.astro
@@ -7,7 +7,7 @@ import LinkButton from "../components/LinkButton.astro";
 <Page title="Submissions" description="Submissions">
   <PageTitle title="Submissions" />
 
-  <h3 class="font-normal font-sans text-2xl m-0 pb-7">We're currently open for submissions. Our submission period closes on February 15th.</h3>
+  <h3 class="font-normal font-sans text-2xl m-0 pb-7">We're currently closed for submissions. Our submission period opens on March 15th.</h3>
   <div class="p-4 bg-lsq-alert border-l-4 mb-10" role="alert">
     <h2 class="mt-0 font-sans text-lg capitalize text-lsq-orange">Our AI policy</h2>
     <div>


### PR DESCRIPTION
## ✅ What
 

1. Added ISBN-10 and ISBN-13 to issue pages Issue 021 through Issue 054. (Closes https://github.com/jenniferlynparsons/lunastationquarterly/issues/73.)
2. Added artistName, artistLink, and koboLink to Issue 049.

 
## 👩‍🔬 How to validate
 
Visit `/issues/` and click on each issue to verify that these changes work as expected.
 
## 🔖 Further reading

N/A

## ⏰ Does this need to be scheduled?

N/A