### PR TITLE
Update home and sidebar to add archive page info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# Local Netlify folder
+.netlify

--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -23,8 +23,8 @@ const currentIssue = filterIssues.length > 0 ? filterIssues[0] : null;
     <h2 class="mt-0 font-sans text-lg font-normal antialiased uppercase">Looking for the story archives?</h2>
     <div class="mt-3 mb-6 border-b-subfooter border-lsq-orange w-1/2"></div>
     <div class="textwidget max-w-52 text-sm">
-      <p>You may have noticed a few changes to the site, particularly around how we&apos;re now presenting our issues. There are some really, really good reasons for that.</p>
-      <LinkButton url={`/changes`} linkText="Learn more" />
+      <p>The archive is back! Head over to our archive page to find out how to access all 17 years of stories.</p>
+      <LinkButton url={`/archive`} linkText="Learn more" />
     </div>
   </aside>
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -10,7 +10,7 @@ import LinkButton from "../components/LinkButton.astro";
 
   <p class="mb-2">
     Luna Station Quarterly has been publishing speculative fiction by women-identified authors since
-    2010. This is all of it: every story, every issue, going all the way back to the beginning.
+    2010. 
   </p>
   <p class="mb-2">
     For a long time the archive was open and free online. Then AI companies started scraping the

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,10 @@ const posts = (await getCollection("blog"))
 ---
 
 <Page title="Homepage" description={SITE_DESCRIPTION}>
+   <div class="p-4 bg-lsq-alert border-l-4 border-lsq-orange mb-8">
+    <p class="my-0 font-sans font-semibold">Looking for our story archive?</p>
+    <p class="my-0">Members can now read every issue going back to 2010. <a href="/archive" class="text-lsq-orange hover:text-lsq-orange-light">Learn more about archive access.</a></p>
+  </div>
   <div class="mb-10">
     {
       posts.map((post) => (


### PR DESCRIPTION
## ✅ What
 
<!-- A brief description of the changes in this PR. -->
 
## 👩‍🔬 How to validate
 
<!-- Step-by-step instructions for how reviewers can verify these changes work as expected. -->
 
## 🔖 Further reading

<!-- Any reference links or related PRs -->

## ⏰ Does this need to be scheduled?

Uncomment one of the lines below, move it to the very bottom, and update the date. The default time is 12am. If you need a more precise, timezone-safe setting, you can use an ISO 8601 date string

`/schedule 2022-06-08`

`/schedule 2022-06-08T09:00:00.000Z`